### PR TITLE
feat: manage singbox and edit inbounds/outbounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Frontend
 **/node_modules/
+**/.nuxt/
 .npm/
 
 # Misc

--- a/backend/Controllers/ClientsController.cs
+++ b/backend/Controllers/ClientsController.cs
@@ -22,12 +22,16 @@ public class ClientsController : ControllerBase
 
     [HttpGet]
     public async Task<IEnumerable<ClientDto>> Get()
-        => _mapper.Map<List<ClientDto>>(await _db.Clients.ToListAsync());
+        => _mapper.Map<List<ClientDto>>(await _db.Clients
+            .Include(c => c.Outbounds)
+            .ToListAsync());
 
     [HttpGet("{id}")]
     public async Task<ActionResult<ClientDto>> Get(int id)
     {
-        var client = await _db.Clients.FindAsync(id);
+        var client = await _db.Clients
+            .Include(c => c.Outbounds)
+            .FirstOrDefaultAsync(c => c.Id == id);
         if (client == null) return NotFound();
         return _mapper.Map<ClientDto>(client);
     }
@@ -48,6 +52,30 @@ public class ClientsController : ControllerBase
         var client = await _db.Clients.FindAsync(id);
         if (client == null) return NotFound();
         _mapper.Map(dto, client);
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPut("{id}/outbounds")]
+    public async Task<IActionResult> SetOutbounds(int id, List<ClientOutboundDto> dtos)
+    {
+        var client = await _db.Clients
+            .Include(c => c.Outbounds)
+            .FirstOrDefaultAsync(c => c.Id == id);
+        if (client == null) return NotFound();
+
+        _db.ClientOutbounds.RemoveRange(client.Outbounds);
+        foreach (var dto in dtos)
+        {
+            _db.ClientOutbounds.Add(new ClientOutbound
+            {
+                ClientId = id,
+                OutboundId = dto.OutboundId,
+                Priority = dto.Priority,
+                Enabled = dto.Enabled
+            });
+        }
+
         await _db.SaveChangesAsync();
         return NoContent();
     }

--- a/backend/Controllers/SingBoxController.cs
+++ b/backend/Controllers/SingBoxController.cs
@@ -1,0 +1,40 @@
+using Backend.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Backend.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SingBoxController : ControllerBase
+{
+    private readonly ISingBoxService _service;
+
+    public SingBoxController(ISingBoxService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet("status")]
+    public IActionResult Status() => Ok(new { running = _service.IsRunning });
+
+    [HttpPost("start")]
+    public async Task<IActionResult> Start()
+    {
+        await _service.StartAsync();
+        return NoContent();
+    }
+
+    [HttpPost("stop")]
+    public async Task<IActionResult> Stop()
+    {
+        await _service.StopAsync();
+        return NoContent();
+    }
+
+    [HttpPost("restart")]
+    public async Task<IActionResult> Restart()
+    {
+        await _service.RestartAsync();
+        return NoContent();
+    }
+}

--- a/backend/Data/AppDbContext.cs
+++ b/backend/Data/AppDbContext.cs
@@ -15,6 +15,7 @@ public class AppDbContext : DbContext
     public DbSet<Client> Clients => Set<Client>();
     public DbSet<Inbound> Inbounds => Set<Inbound>();
     public DbSet<Outbound> Outbounds => Set<Outbound>();
+    public DbSet<ClientOutbound> ClientOutbounds => Set<ClientOutbound>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -25,6 +26,19 @@ public class AppDbContext : DbContext
         modelBuilder.Entity<Client>()
             .Property(c => c.Tags)
             .HasConversion(tagsConverter);
+
+        modelBuilder.Entity<ClientOutbound>()
+            .HasKey(co => new { co.ClientId, co.OutboundId });
+
+        modelBuilder.Entity<ClientOutbound>()
+            .HasOne(co => co.Client)
+            .WithMany(c => c.Outbounds)
+            .HasForeignKey(co => co.ClientId);
+
+        modelBuilder.Entity<ClientOutbound>()
+            .HasOne(co => co.Outbound)
+            .WithMany(o => o.Clients)
+            .HasForeignKey(co => co.OutboundId);
 
         base.OnModelCreating(modelBuilder);
     }

--- a/backend/Data/Migrations/20250820195606_AddClientOutbounds.Designer.cs
+++ b/backend/Data/Migrations/20250820195606_AddClientOutbounds.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Backend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Backend.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250820195606_AddClientOutbounds")]
+    partial class AddClientOutbounds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.8");

--- a/backend/Data/Migrations/20250820195606_AddClientOutbounds.cs
+++ b/backend/Data/Migrations/20250820195606_AddClientOutbounds.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Backend.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClientOutbounds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ClientOutbounds",
+                columns: table => new
+                {
+                    ClientId = table.Column<int>(type: "INTEGER", nullable: false),
+                    OutboundId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Priority = table.Column<int>(type: "INTEGER", nullable: false),
+                    Enabled = table.Column<bool>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ClientOutbounds", x => new { x.ClientId, x.OutboundId });
+                    table.ForeignKey(
+                        name: "FK_ClientOutbounds_Clients_ClientId",
+                        column: x => x.ClientId,
+                        principalTable: "Clients",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ClientOutbounds_Outbounds_OutboundId",
+                        column: x => x.OutboundId,
+                        principalTable: "Outbounds",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ClientOutbounds_OutboundId",
+                table: "ClientOutbounds",
+                column: "OutboundId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ClientOutbounds");
+        }
+    }
+}

--- a/backend/Dtos/ClientDto.cs
+++ b/backend/Dtos/ClientDto.cs
@@ -8,5 +8,6 @@ public class ClientDto
     public bool IsOnline { get; set; }
     public DateTime? LastSeenAt { get; set; }
     public string? Notes { get; set; }
+    public List<ClientOutboundDto> Outbounds { get; set; } = new();
 }
 

--- a/backend/Dtos/ClientOutboundDto.cs
+++ b/backend/Dtos/ClientOutboundDto.cs
@@ -1,0 +1,9 @@
+namespace Backend.Dtos;
+
+public class ClientOutboundDto
+{
+    public int OutboundId { get; set; }
+    public int Priority { get; set; }
+    public bool Enabled { get; set; }
+}
+

--- a/backend/Mapping/MappingProfile.cs
+++ b/backend/Mapping/MappingProfile.cs
@@ -11,6 +11,7 @@ public class MappingProfile : Profile
         CreateMap<Client, ClientDto>().ReverseMap();
         CreateMap<Inbound, InboundDto>().ReverseMap();
         CreateMap<Outbound, OutboundDto>().ReverseMap();
+        CreateMap<ClientOutbound, ClientOutboundDto>().ReverseMap();
     }
 }
 

--- a/backend/Models/Client.cs
+++ b/backend/Models/Client.cs
@@ -16,5 +16,7 @@ public class Client
     public DateTime? LastSeenAt { get; set; }
 
     public string? Notes { get; set; }
+
+    public List<ClientOutbound> Outbounds { get; set; } = new();
 }
 

--- a/backend/Models/ClientOutbound.cs
+++ b/backend/Models/ClientOutbound.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Backend.Models;
+
+public class ClientOutbound
+{
+    [Required]
+    public int ClientId { get; set; }
+
+    [Required]
+    public int OutboundId { get; set; }
+
+    public int Priority { get; set; }
+
+    public bool Enabled { get; set; }
+
+    public Client? Client { get; set; }
+    public Outbound? Outbound { get; set; }
+}
+

--- a/backend/Models/Outbound.cs
+++ b/backend/Models/Outbound.cs
@@ -21,5 +21,7 @@ public class Outbound
 
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
+
+    public List<ClientOutbound> Clients { get; set; } = new();
 }
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -3,6 +3,7 @@ using Backend.Mapping;
 using Microsoft.EntityFrameworkCore;
 using FluentValidation.AspNetCore;
 using FluentValidation;
+using Backend.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,6 +14,7 @@ builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 builder.Services.AddAutoMapper(typeof(MappingProfile));
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlite(builder.Configuration.GetConnectionString("Default")));
+builder.Services.AddSingleton<ISingBoxService, SingBoxService>();
 
 var app = builder.Build();
 

--- a/backend/Services/SingBoxService.cs
+++ b/backend/Services/SingBoxService.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+
+namespace Backend.Services;
+
+public interface ISingBoxService
+{
+    bool IsRunning { get; }
+    Task StartAsync();
+    Task StopAsync();
+    Task RestartAsync();
+}
+
+public class SingBoxService : ISingBoxService
+{
+    private Process? _process;
+    private readonly string _binaryPath;
+    private readonly string _configPath;
+
+    public SingBoxService(IConfiguration config)
+    {
+        _binaryPath = config.GetValue<string>("SingBox:BinaryPath") ?? "sing-box";
+        _configPath = config.GetValue<string>("SingBox:ConfigPath") ?? "singbox.json";
+    }
+
+    public bool IsRunning => _process != null && !_process.HasExited;
+
+    public Task StartAsync()
+    {
+        if (IsRunning) return Task.CompletedTask;
+        _process = Process.Start(new ProcessStartInfo
+        {
+            FileName = _binaryPath,
+            Arguments = $"run -c {_configPath}",
+            UseShellExecute = false,
+        });
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync()
+    {
+        if (IsRunning)
+        {
+            _process!.Kill(true);
+            _process!.WaitForExit();
+            _process = null;
+        }
+        return Task.CompletedTask;
+    }
+
+    public async Task RestartAsync()
+    {
+        await StopAsync();
+        await StartAsync();
+    }
+}

--- a/backend/Validators/ClientDtoValidator.cs
+++ b/backend/Validators/ClientDtoValidator.cs
@@ -8,6 +8,7 @@ public class ClientDtoValidator : AbstractValidator<ClientDto>
     public ClientDtoValidator()
     {
         RuleFor(x => x.Name).NotEmpty();
+        RuleForEach(x => x.Outbounds).SetValidator(new ClientOutboundDtoValidator());
     }
 }
 

--- a/backend/Validators/ClientOutboundDtoValidator.cs
+++ b/backend/Validators/ClientOutboundDtoValidator.cs
@@ -1,0 +1,13 @@
+using Backend.Dtos;
+using FluentValidation;
+
+namespace Backend.Validators;
+
+public class ClientOutboundDtoValidator : AbstractValidator<ClientOutboundDto>
+{
+    public ClientOutboundDtoValidator()
+    {
+        RuleFor(x => x.OutboundId).GreaterThan(0);
+    }
+}
+

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+.nuxt

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,21 +1,21 @@
 module.exports = {
   root: true,
-  env: {
-    browser: true,
-    node: true,
-    es2021: true,
-  },
+  env: { browser: true, es2021: true, node: true },
   extends: [
     'eslint:recommended',
     'plugin:vue/vue3-recommended',
     'plugin:@typescript-eslint/recommended',
-    'prettier',
+    'prettier'
   ],
   parser: 'vue-eslint-parser',
   parserOptions: {
     parser: '@typescript-eslint/parser',
-    sourceType: 'module',
     ecmaVersion: 2021,
+    sourceType: 'module'
   },
-  rules: {},
-};
+  plugins: ['vue', '@typescript-eslint'],
+  rules: {
+    'vue/multi-word-component-names': 'off',
+    'vue/valid-v-slot': 'off'
+  }
+}

--- a/frontend/components/OutboundMappingDialog.vue
+++ b/frontend/components/OutboundMappingDialog.vue
@@ -1,0 +1,109 @@
+<template>
+  <v-dialog v-model="dialog" max-width="600">
+    <v-card>
+      <v-card-title>Assign Outbounds</v-card-title>
+      <v-card-text>
+        <v-list>
+          <v-list-item
+            v-for="(item, index) in assigned"
+            :key="item.outboundId"
+            draggable="true"
+            @dragstart="onDragStart(index)"
+            @dragover.prevent
+            @drop="onDrop(index)"
+          >
+            <v-list-item-title>{{ outboundName(item.outboundId) }}</v-list-item-title>
+            <template #append>
+              <v-switch v-model="item.enabled" class="mr-2" />
+              <v-btn variant="text" size="small" @click="remove(index)">Remove</v-btn>
+            </template>
+          </v-list-item>
+        </v-list>
+        <v-select
+          v-model="selected"
+          :items="availableOutbounds"
+          item-title="name"
+          item-value="id"
+          label="Add Outbound"
+          @update:model-value="add"
+        />
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn variant="text" @click="dialog = false">Cancel</v-btn>
+        <v-btn color="primary" @click="save">Save</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useClientsStore, type ClientOutbound } from '~/stores/clients'
+import { useOutboundsStore } from '~/stores/outbounds'
+
+const props = defineProps<{ modelValue: boolean; clientId: number }>()
+const emit = defineEmits(['update:modelValue'])
+
+const dialog = computed({
+  get: () => props.modelValue,
+  set: (v: boolean) => emit('update:modelValue', v),
+})
+
+const clientsStore = useClientsStore()
+const outboundsStore = useOutboundsStore()
+
+const assigned = ref<ClientOutbound[]>([])
+const selected = ref<number | null>(null)
+const dragIndex = ref<number | null>(null)
+
+watch(
+  () => props.clientId,
+  (id) => {
+    const client = clientsStore.clients.find((c) => c.id === id)
+    assigned.value = client ? [...client.outbounds].sort((a, b) => a.priority - b.priority) : []
+  },
+  { immediate: true }
+)
+
+const availableOutbounds = computed(() =>
+  outboundsStore.outbounds.filter((o) => !assigned.value.some((a) => a.outboundId === o.id))
+)
+
+function outboundName(id: number) {
+  return outboundsStore.outbounds.find((o) => o.id === id)?.name || `#${id}`
+}
+
+function add(id: number | null) {
+  if (!id) return
+  assigned.value.push({ outboundId: id, priority: assigned.value.length + 1, enabled: true })
+  selected.value = null
+}
+
+function remove(index: number) {
+  assigned.value.splice(index, 1)
+}
+
+function onDragStart(index: number) {
+  dragIndex.value = index
+}
+
+function onDrop(index: number) {
+  if (dragIndex.value === null) return
+  const item = assigned.value.splice(dragIndex.value, 1)[0]
+  assigned.value.splice(index, 0, item)
+  dragIndex.value = null
+}
+
+async function save() {
+  assigned.value.forEach((a, idx) => (a.priority = idx + 1))
+  await clientsStore.updateOutbounds(props.clientId, assigned.value)
+  dialog.value = false
+}
+
+onMounted(async () => {
+  if (!outboundsStore.outbounds.length) {
+    await outboundsStore.fetch()
+  }
+})
+</script>

--- a/frontend/pages/clients/index.vue
+++ b/frontend/pages/clients/index.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-container>
+    <v-btn color="primary" class="mb-4" @click="refresh">Refresh</v-btn>
+    <v-data-table :headers="headers" :items="clientsStore.clients">
+      <template #item.tags="{ item }">
+        {{ item.tags.join(', ') }}
+      </template>
+      <template #item.outbounds="{ item }">
+        {{ item.outbounds.length }}
+      </template>
+      <template #item.actions="{ item }">
+        <v-btn variant="text" @click="openDialog(item.id)">Outbounds</v-btn>
+      </template>
+    </v-data-table>
+    <OutboundMappingDialog v-model="dialog" :client-id="currentClientId" />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useClientsStore } from '~/stores/clients'
+import OutboundMappingDialog from '~/components/OutboundMappingDialog.vue'
+
+const clientsStore = useClientsStore()
+
+const headers = [
+  { title: 'Name', key: 'name' },
+  { title: 'Tags', key: 'tags' },
+  { title: 'Outbounds', key: 'outbounds' },
+  { title: 'Actions', key: 'actions', sortable: false },
+]
+
+const dialog = ref(false)
+const currentClientId = ref(0)
+
+function openDialog(id: number) {
+  currentClientId.value = id
+  dialog.value = true
+}
+
+async function refresh() {
+  await clientsStore.fetch()
+}
+
+onMounted(refresh)
+</script>

--- a/frontend/pages/inbounds/index.vue
+++ b/frontend/pages/inbounds/index.vue
@@ -1,0 +1,71 @@
+<template>
+  <v-container>
+    <v-btn color="primary" class="mb-4" @click="openCreate">Add Inbound</v-btn>
+    <v-data-table :headers="headers" :items="store.inbounds">
+      <template #item.actions="{ item }">
+        <v-btn variant="text" @click="openEdit(item)">Edit</v-btn>
+        <v-btn variant="text" color="error" @click="remove(item.id)">Delete</v-btn>
+      </template>
+    </v-data-table>
+    <v-dialog v-model="dialog" max-width="600">
+      <v-card>
+        <v-card-title>{{ editing ? 'Edit' : 'Create' }} Inbound</v-card-title>
+        <v-card-text>
+          <v-text-field v-model="form.name" label="Name" />
+          <v-text-field v-model="form.type" label="Type" />
+          <v-text-field v-model="form.version" label="Version" />
+          <v-switch v-model="form.enabled" label="Enabled" />
+          <v-textarea v-model="form.jsonConfig" label="JSON Config" rows="10" />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="dialog = false">Cancel</v-btn>
+          <v-btn color="primary" @click="save">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useInboundsStore, type Inbound } from '~/stores/inbounds'
+
+const store = useInboundsStore()
+const headers = [
+  { title: 'Name', key: 'name' },
+  { title: 'Type', key: 'type' },
+  { title: 'Actions', key: 'actions', sortable: false },
+]
+
+const dialog = ref(false)
+const editing = ref(false)
+const editId = ref(0)
+const form = ref<Partial<Inbound>>({ name: '', type: '', version: '', jsonConfig: '{}', enabled: true })
+
+function openCreate() {
+  editing.value = false
+  editId.value = 0
+  form.value = { name: '', type: '', version: '', jsonConfig: '{}', enabled: true }
+  dialog.value = true
+}
+
+function openEdit(item: Inbound) {
+  editing.value = true
+  editId.value = item.id
+  form.value = { ...item }
+  dialog.value = true
+}
+
+async function save() {
+  if (editing.value) await store.update(editId.value, form.value)
+  else await store.create(form.value)
+  dialog.value = false
+}
+
+async function remove(id: number) {
+  await store.remove(id)
+}
+
+onMounted(() => store.fetch())
+</script>

--- a/frontend/pages/outbounds/index.vue
+++ b/frontend/pages/outbounds/index.vue
@@ -1,0 +1,71 @@
+<template>
+  <v-container>
+    <v-btn color="primary" class="mb-4" @click="openCreate">Add Outbound</v-btn>
+    <v-data-table :headers="headers" :items="store.outbounds">
+      <template #item.actions="{ item }">
+        <v-btn variant="text" @click="openEdit(item)">Edit</v-btn>
+        <v-btn variant="text" color="error" @click="remove(item.id)">Delete</v-btn>
+      </template>
+    </v-data-table>
+    <v-dialog v-model="dialog" max-width="600">
+      <v-card>
+        <v-card-title>{{ editing ? 'Edit' : 'Create' }} Outbound</v-card-title>
+        <v-card-text>
+          <v-text-field v-model="form.name" label="Name" />
+          <v-text-field v-model="form.type" label="Type" />
+          <v-text-field v-model="form.version" label="Version" />
+          <v-switch v-model="form.enabled" label="Enabled" />
+          <v-textarea v-model="form.jsonConfig" label="JSON Config" rows="10" />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="dialog = false">Cancel</v-btn>
+          <v-btn color="primary" @click="save">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useOutboundsStore, type Outbound } from '~/stores/outbounds'
+
+const store = useOutboundsStore()
+const headers = [
+  { title: 'Name', key: 'name' },
+  { title: 'Type', key: 'type' },
+  { title: 'Actions', key: 'actions', sortable: false },
+]
+
+const dialog = ref(false)
+const editing = ref(false)
+const editId = ref(0)
+const form = ref<Partial<Outbound>>({ name: '', type: '', version: '', jsonConfig: '{}', enabled: true })
+
+function openCreate() {
+  editing.value = false
+  editId.value = 0
+  form.value = { name: '', type: '', version: '', jsonConfig: '{}', enabled: true }
+  dialog.value = true
+}
+
+function openEdit(item: Outbound) {
+  editing.value = true
+  editId.value = item.id
+  form.value = { ...item }
+  dialog.value = true
+}
+
+async function save() {
+  if (editing.value) await store.update(editId.value, form.value)
+  else await store.create(form.value)
+  dialog.value = false
+}
+
+async function remove(id: number) {
+  await store.remove(id)
+}
+
+onMounted(() => store.fetch())
+</script>

--- a/frontend/pages/settings/index.vue
+++ b/frontend/pages/settings/index.vue
@@ -1,0 +1,17 @@
+<template>
+  <v-container>
+    <p>Sing-box running: {{ store.running }}</p>
+    <v-btn class="mr-2" @click="store.start">Start</v-btn>
+    <v-btn class="mr-2" @click="store.stop">Stop</v-btn>
+    <v-btn class="mr-2" @click="store.restart">Restart</v-btn>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useSingBoxStore } from '~/stores/singbox'
+
+const store = useSingBoxStore()
+
+onMounted(() => store.fetchStatus())
+</script>

--- a/frontend/stores/clients.ts
+++ b/frontend/stores/clients.ts
@@ -1,0 +1,38 @@
+import { defineStore } from 'pinia'
+
+export interface ClientOutbound {
+  outboundId: number
+  priority: number
+  enabled: boolean
+}
+
+export interface Client {
+  id: number
+  name: string
+  tags: string[]
+  isOnline: boolean
+  lastSeenAt?: string
+  notes?: string
+  outbounds: ClientOutbound[]
+}
+
+export const useClientsStore = defineStore('clients', {
+  state: () => ({
+    clients: [] as Client[],
+  }),
+  actions: {
+    async fetch() {
+      this.clients = await $fetch<Client[]>('/api/clients')
+    },
+    async updateOutbounds(clientId: number, outbounds: ClientOutbound[]) {
+      await $fetch(`/api/clients/${clientId}/outbounds`, {
+        method: 'PUT',
+        body: outbounds,
+      })
+      const client = this.clients.find((c) => c.id === clientId)
+      if (client) {
+        client.outbounds = outbounds
+      }
+    },
+  },
+})

--- a/frontend/stores/inbounds.ts
+++ b/frontend/stores/inbounds.ts
@@ -1,0 +1,40 @@
+import { defineStore } from 'pinia'
+
+export interface Inbound {
+  id: number
+  name: string
+  type: string
+  version: string
+  jsonConfig: string
+  enabled: boolean
+}
+
+export const useInboundsStore = defineStore('inbounds', {
+  state: () => ({
+    inbounds: [] as Inbound[],
+  }),
+  actions: {
+    async fetch() {
+      this.inbounds = await $fetch<Inbound[]>('/api/inbounds')
+    },
+    async create(data: Partial<Inbound>) {
+      const inbound = await $fetch<Inbound>('/api/inbounds', {
+        method: 'POST',
+        body: data,
+      })
+      this.inbounds.push(inbound)
+    },
+    async update(id: number, data: Partial<Inbound>) {
+      await $fetch(`/api/inbounds/${id}`, {
+        method: 'PUT',
+        body: data,
+      })
+      const idx = this.inbounds.findIndex((i) => i.id === id)
+      if (idx !== -1) this.inbounds[idx] = { ...this.inbounds[idx], ...data }
+    },
+    async remove(id: number) {
+      await $fetch(`/api/inbounds/${id}`, { method: 'DELETE' })
+      this.inbounds = this.inbounds.filter((i) => i.id !== id)
+    },
+  },
+})

--- a/frontend/stores/outbounds.ts
+++ b/frontend/stores/outbounds.ts
@@ -1,0 +1,40 @@
+import { defineStore } from 'pinia'
+
+export interface Outbound {
+  id: number
+  name: string
+  type: string
+  version: string
+  jsonConfig: string
+  enabled: boolean
+}
+
+export const useOutboundsStore = defineStore('outbounds', {
+  state: () => ({
+    outbounds: [] as Outbound[],
+  }),
+  actions: {
+    async fetch() {
+      this.outbounds = await $fetch<Outbound[]>('/api/outbounds')
+    },
+    async create(data: Partial<Outbound>) {
+      const outbound = await $fetch<Outbound>('/api/outbounds', {
+        method: 'POST',
+        body: data,
+      })
+      this.outbounds.push(outbound)
+    },
+    async update(id: number, data: Partial<Outbound>) {
+      await $fetch(`/api/outbounds/${id}`, {
+        method: 'PUT',
+        body: data,
+      })
+      const idx = this.outbounds.findIndex((o) => o.id === id)
+      if (idx !== -1) this.outbounds[idx] = { ...this.outbounds[idx], ...data }
+    },
+    async remove(id: number) {
+      await $fetch(`/api/outbounds/${id}`, { method: 'DELETE' })
+      this.outbounds = this.outbounds.filter((o) => o.id !== id)
+    },
+  },
+})

--- a/frontend/stores/singbox.ts
+++ b/frontend/stores/singbox.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+
+export const useSingBoxStore = defineStore('singbox', {
+  state: () => ({
+    running: false,
+  }),
+  actions: {
+    async fetchStatus() {
+      const res = await $fetch<{ running: boolean }>('/api/singbox/status')
+      this.running = res.running
+    },
+    async start() {
+      await $fetch('/api/singbox/start', { method: 'POST' })
+      this.running = true
+    },
+    async stop() {
+      await $fetch('/api/singbox/stop', { method: 'POST' })
+      this.running = false
+    },
+    async restart() {
+      await $fetch('/api/singbox/restart', { method: 'POST' })
+      this.running = true
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add SingBox service and controller to start, stop and restart the sing-box process
- add CRUD pages and stores for inbounds and outbounds
- add settings page and store to control sing-box runtime

## Testing
- `npm run lint`
- `npm test`
- `dotnet build backend`
- `dotnet test backend`


------
https://chatgpt.com/codex/tasks/task_e_68a6278b4b84833091f867a1f60f1795